### PR TITLE
add THT token configuration to oraidex.json

### DIFF
--- a/packages/oraidex-common/src/supported/config/oraidex.json
+++ b/packages/oraidex-common/src/supported/config/oraidex.json
@@ -103,6 +103,10 @@
     "HTT": {
       "denom": "cw20:orai1k5d5cgekt8kkzcrnxrx860wadvz5esjwtyv299g0ht75a92yfn6qvgu0ml:OCH",
       "coingecko_id": "osmosis"
+    },
+    "THT": {
+      "denom": "cw20:orai1fkz48mkvw9cs848kjmr69gn7znj9flyc3vd2xvzud7h2x36xaj7q6p48re:THT",
+      "coingecko_id": "polkadot"
     }
   },
   "celestia": {


### PR DESCRIPTION
This pull request includes changes to the `oraidex.json` configuration file to add support for a new token. The most important change is the addition of the `THT` token with its corresponding `denom` and `coingecko_id`.

Changes in token support:

* [`packages/oraidex-common/src/supported/config/oraidex.json`](diffhunk://#diff-bcdc0cf384b2f5a2a6094a11342decd0f50529ea90b9932524969d0b67202879R106-R109): Added support for the `THT` token with `denom` set to `cw20:orai1fkz48mkvw9cs848kjmr69gn7znj9flyc3vd2xvzud7h2x36xaj7q6p48re:THT` and `coingecko_id` set to `polkadot`.